### PR TITLE
update for 10.0.300 release

### DIFF
--- a/flat/cat.cs
+++ b/flat/cat.cs
@@ -1,15 +1,11 @@
 #!/usr/bin/env dotnet
 
-// Properties to enable experimental features for file-based apps
-// - include/exclude directives moving to non-experimental in 10.0.300
-// - transitive directives experimental status still being debated for 10.0.300
+// Transitive directives are experimental in 10.0.300
 // Note: These could be put in a `Directory.Build.props` file instead if preferred
-#:property ExperimentalFileBasedProgramEnableIncludeDirective=true
-#:property ExperimentalFileBasedProgramEnableExcludeDirective=true
 #:property ExperimentalFileBasedProgramEnableTransitiveDirectives=true
 
 // Include other files in the virtual project, item type is inferred from the file extension
-// Note: Using globs here is supported but effectively disables MSBuild caching atm
+// Note: Using globs here is supported but effectively disables MSBuild caching for now
 #:include ./cat.commands.cs
 
 var rootCommand = CatCli.Commands.DefineRootCommand();

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.300-preview.0.26217.103",
+    "version": "10.0.300",
     "rollForward": "latestFeature",
     "allowPrerelease": true
   }


### PR DESCRIPTION
Updated `cat.cs` sample to use `#:include` directive to enable multiple files.